### PR TITLE
Switch Unity Editor to version 2022.3.40f1 to align with lab setup

### DIFF
--- a/Alt-Ship/Packages/packages-lock.json
+++ b/Alt-Ship/Packages/packages-lock.json
@@ -147,7 +147,7 @@
       }
     },
     "com.unity.scriptablebuildpipeline": {
-      "version": "1.21.24",
+      "version": "1.21.23",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -214,9 +214,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"

--- a/Alt-Ship/ProjectSettings/ProjectVersion.txt
+++ b/Alt-Ship/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.41f1
-m_EditorVersionWithRevision: 2022.3.41f1 (0f988161febf)
+m_EditorVersion: 2022.3.40f1
+m_EditorVersionWithRevision: 2022.3.40f1 (cbdda657d2f0)


### PR DESCRIPTION
This PR updates the Unity Editor version to 2022.3.40f1 to match the version used in the lab environment.